### PR TITLE
Bumping fluentd dependency to get rid of issue with msgpack

### DIFF
--- a/fluent-plugin-splunk-ex.gemspec
+++ b/fluent-plugin-splunk-ex.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name         = "fluent-plugin-splunk-ex"
-  gem.version      = "1.0.1"
+  gem.version      = "1.0.3"
 
   gem.authors      = ["Trevor Gattis"]
   gem.email        = "github@trevorgattis.com"
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", "~> 0.10.17"
+  gem.add_dependency "fluentd", "~> 0.12.22"
   gem.add_runtime_dependency "json"
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Fixes #5 

The old fluentd dependency did not have support for ruby 2.5

@gtrevg would you be able to build a new version with this new dependency?